### PR TITLE
feat: rename site to Snowcation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,7 +10,7 @@ export default defineConfig({
     integrations: [
         mermaid(),
         starlight({
-            title: 'Snowcation Guide',
+            title: 'Snowcation',
             defaultLocale: 'ja',
             social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/kyosuke/snowcation' }],
             sidebar: [

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,12 +1,12 @@
 ---
-title: Snowcation Guide
-description: Documentation for Snowcation Guide.
+title: Snowcation
+description: Documentation for Snowcation.
 template: doc
 ---
 
 ## サイトコンセプト
 
-**Snowcation Guide** へようこそ。
+**Snowcation** へようこそ。
 
 このサイトは、スキー場でのワーケーション（スノーケーション）を快適に行うための情報を集約したガイドサイトです。
 各スキー場のゲレンデ情報だけでなく、周辺の宿泊施設、Wi-Fi環境、アクセス情報などを体系的にまとめています。


### PR DESCRIPTION
Fixes #7. Renamed the site from 'Snowcation Guide' to 'Snowcation' in configuration and index page.