### PR TITLE
replace mermaid with d2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # build output
 dist/
+
+# astro-d2 generated SVGs
+public/d2/
 # generated types
 .astro/
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
-import mermaid from 'astro-mermaid';
+import astroD2 from 'astro-d2';
 import Icons from 'unplugin-icons/vite';
 
 import cloudflare from '@astrojs/cloudflare';
@@ -16,7 +16,11 @@ export default defineConfig({
         ],
     },
     integrations: [
-        mermaid(),
+        astroD2({
+            layout: 'elk',
+            theme: { default: '104', dark: '200' },
+            experimental: { useD2js: true },
+        }),
         starlight({
             title: 'Snowcation',
             defaultLocale: 'ja',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"@astrojs/cloudflare": "^12.6.10",
 				"@astrojs/starlight": "^0.36.2",
 				"astro": "^5.6.1",
-				"astro-mermaid": "^1.1.0",
+				"astro-d2": "^0.9.0",
 				"sharp": "^0.34.2"
 			},
 			"devDependencies": {
@@ -25,6 +25,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
 			"integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"package-manager-detector": "^1.3.0",
@@ -1310,12 +1311,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@braintree/sanitize-url": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.1.tgz",
-			"integrity": "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==",
-			"license": "MIT"
-		},
 		"node_modules/@capsizecss/unpack": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-3.0.1.tgz",
@@ -1327,45 +1322,6 @@
 			"engines": {
 				"node": ">=18"
 			}
-		},
-		"node_modules/@chevrotain/cst-dts-gen": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-			"integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@chevrotain/gast": "11.0.3",
-				"@chevrotain/types": "11.0.3",
-				"lodash-es": "4.17.21"
-			}
-		},
-		"node_modules/@chevrotain/gast": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-			"integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@chevrotain/types": "11.0.3",
-				"lodash-es": "4.17.21"
-			}
-		},
-		"node_modules/@chevrotain/regexp-to-ast": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-			"integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
-			"license": "Apache-2.0"
-		},
-		"node_modules/@chevrotain/types": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-			"integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
-			"license": "Apache-2.0"
-		},
-		"node_modules/@chevrotain/utils": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-			"integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
-			"license": "Apache-2.0"
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
 			"version": "0.4.0",
@@ -1993,12 +1949,14 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
 			"integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@iconify/utils": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
 			"integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@antfu/install-pkg": "^1.1.0",
@@ -2577,15 +2535,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/@mermaid-js/parser": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.3.tgz",
-			"integrity": "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==",
-			"license": "MIT",
-			"dependencies": {
-				"langium": "3.3.1"
-			}
-		},
 		"node_modules/@oslojs/encoding": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -3119,258 +3068,11 @@
 				"tslib": "^2.8.0"
 			}
 		},
-		"node_modules/@types/d3": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
-			"integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-array": "*",
-				"@types/d3-axis": "*",
-				"@types/d3-brush": "*",
-				"@types/d3-chord": "*",
-				"@types/d3-color": "*",
-				"@types/d3-contour": "*",
-				"@types/d3-delaunay": "*",
-				"@types/d3-dispatch": "*",
-				"@types/d3-drag": "*",
-				"@types/d3-dsv": "*",
-				"@types/d3-ease": "*",
-				"@types/d3-fetch": "*",
-				"@types/d3-force": "*",
-				"@types/d3-format": "*",
-				"@types/d3-geo": "*",
-				"@types/d3-hierarchy": "*",
-				"@types/d3-interpolate": "*",
-				"@types/d3-path": "*",
-				"@types/d3-polygon": "*",
-				"@types/d3-quadtree": "*",
-				"@types/d3-random": "*",
-				"@types/d3-scale": "*",
-				"@types/d3-scale-chromatic": "*",
-				"@types/d3-selection": "*",
-				"@types/d3-shape": "*",
-				"@types/d3-time": "*",
-				"@types/d3-time-format": "*",
-				"@types/d3-timer": "*",
-				"@types/d3-transition": "*",
-				"@types/d3-zoom": "*"
-			}
-		},
-		"node_modules/@types/d3-array": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-			"integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-axis": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
-			"integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"node_modules/@types/d3-brush": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
-			"integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"node_modules/@types/d3-chord": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
-			"integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-color": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-contour": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
-			"integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-array": "*",
-				"@types/geojson": "*"
-			}
-		},
-		"node_modules/@types/d3-delaunay": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-			"integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-dispatch": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
-			"integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-drag": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
-			"integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"node_modules/@types/d3-dsv": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
-			"integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-ease": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-			"integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-fetch": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
-			"integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-dsv": "*"
-			}
-		},
-		"node_modules/@types/d3-force": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
-			"integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-format": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
-			"integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-geo": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-			"integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/geojson": "*"
-			}
-		},
-		"node_modules/@types/d3-hierarchy": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
-			"integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-interpolate": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-			"integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-color": "*"
-			}
-		},
-		"node_modules/@types/d3-path": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-			"integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-polygon": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
-			"integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-quadtree": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
-			"integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-random": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
-			"integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-scale": {
-			"version": "4.0.9",
-			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-			"integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-time": "*"
-			}
-		},
-		"node_modules/@types/d3-scale-chromatic": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-			"integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-selection": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
-			"integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-shape": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
-			"integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-path": "*"
-			}
-		},
-		"node_modules/@types/d3-time": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-time-format": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
-			"integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-timer": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-transition": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
-			"integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"node_modules/@types/d3-zoom": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
-			"integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-interpolate": "*",
-				"@types/d3-selection": "*"
-			}
+		"node_modules/@terrastruct/d2": {
+			"version": "0.1.33",
+			"resolved": "https://registry.npmjs.org/@terrastruct/d2/-/d2-0.1.33.tgz",
+			"integrity": "sha512-eK5hyfGIJFolC7sUsiKvWdY9xGFctTe3d+PSijo09IYDso8psztC+A4SammizXtlwYZpnnW0AtDjfBYauceSeA==",
+			"license": "MPL-2.0"
 		},
 		"node_modules/@types/debug": {
 			"version": "4.1.12",
@@ -3404,12 +3106,6 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/geojson": {
-			"version": "7946.0.16",
-			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-			"license": "MIT"
 		},
 		"node_modules/@types/hast": {
 			"version": "3.0.4",
@@ -3473,13 +3169,6 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/trusted-types": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"license": "MIT",
-			"optional": true
 		},
 		"node_modules/@types/unist": {
 			"version": "3.0.3",
@@ -3749,6 +3438,24 @@
 				"sharp": "^0.34.0"
 			}
 		},
+		"node_modules/astro-d2": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/astro-d2/-/astro-d2-0.9.0.tgz",
+			"integrity": "sha512-an5vkji/rPL5rgULj1u85cgWvW9Za5htrvYcx3My1jAQLFgBxgUmsw7p9Il9yFnpjj/KemZDlV6WdSzhJAlvbQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@terrastruct/d2": "^0.1.33",
+				"hast-util-from-html": "^2.0.3",
+				"hast-util-to-html": "^9.0.4",
+				"unist-util-visit": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"astro": ">=5.0.0"
+			}
+		},
 		"node_modules/astro-expressive-code": {
 			"version": "0.41.3",
 			"resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.41.3.tgz",
@@ -3759,27 +3466,6 @@
 			},
 			"peerDependencies": {
 				"astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0"
-			}
-		},
-		"node_modules/astro-mermaid": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/astro-mermaid/-/astro-mermaid-1.1.0.tgz",
-			"integrity": "sha512-eW5aqOISq2Uf8goCedSl12d0qy8y77A+jRwKxwYc7LvrEN9HiCQuwTGu3zQvi0mB4+ydwaueaYbFUFSCIs2jrA==",
-			"license": "MIT",
-			"dependencies": {
-				"import-meta-resolve": "^4.2.0",
-				"mdast-util-to-string": "^4.0.0",
-				"unist-util-visit": "^5.0.0"
-			},
-			"peerDependencies": {
-				"@mermaid-js/layout-elk": "^0.2.0",
-				"astro": "^4.0.0 || ^5.0.0",
-				"mermaid": "^10.0.0 || ^11.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@mermaid-js/layout-elk": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/axobject-query": {
@@ -3969,33 +3655,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/chevrotain": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-			"integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@chevrotain/cst-dts-gen": "11.0.3",
-				"@chevrotain/gast": "11.0.3",
-				"@chevrotain/regexp-to-ast": "11.0.3",
-				"@chevrotain/types": "11.0.3",
-				"@chevrotain/utils": "11.0.3",
-				"lodash-es": "4.17.21"
-			}
-		},
-		"node_modules/chevrotain-allstar": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-			"integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
-			"license": "MIT",
-			"dependencies": {
-				"lodash-es": "^4.17.21"
-			},
-			"peerDependencies": {
-				"chevrotain": "^11.0.0"
-			}
-		},
 		"node_modules/chokidar": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -4117,15 +3776,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/commander": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10"
-			}
-		},
 		"node_modules/common-ancestor-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
@@ -4153,15 +3803,6 @@
 			"resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
 			"integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
 			"license": "MIT"
-		},
-		"node_modules/cose-base": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
-			"integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
-			"license": "MIT",
-			"dependencies": {
-				"layout-base": "^1.0.0"
-			}
 		},
 		"node_modules/crossws": {
 			"version": "0.3.5",
@@ -4213,513 +3854,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/cytoscape": {
-			"version": "3.33.1",
-			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
-			"integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/cytoscape-cose-bilkent": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
-			"integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
-			"license": "MIT",
-			"dependencies": {
-				"cose-base": "^1.0.0"
-			},
-			"peerDependencies": {
-				"cytoscape": "^3.2.0"
-			}
-		},
-		"node_modules/cytoscape-fcose": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
-			"integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
-			"license": "MIT",
-			"dependencies": {
-				"cose-base": "^2.2.0"
-			},
-			"peerDependencies": {
-				"cytoscape": "^3.2.0"
-			}
-		},
-		"node_modules/cytoscape-fcose/node_modules/cose-base": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
-			"integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
-			"license": "MIT",
-			"dependencies": {
-				"layout-base": "^2.0.0"
-			}
-		},
-		"node_modules/cytoscape-fcose/node_modules/layout-base": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
-			"integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
-			"license": "MIT"
-		},
-		"node_modules/d3": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
-			"integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "3",
-				"d3-axis": "3",
-				"d3-brush": "3",
-				"d3-chord": "3",
-				"d3-color": "3",
-				"d3-contour": "4",
-				"d3-delaunay": "6",
-				"d3-dispatch": "3",
-				"d3-drag": "3",
-				"d3-dsv": "3",
-				"d3-ease": "3",
-				"d3-fetch": "3",
-				"d3-force": "3",
-				"d3-format": "3",
-				"d3-geo": "3",
-				"d3-hierarchy": "3",
-				"d3-interpolate": "3",
-				"d3-path": "3",
-				"d3-polygon": "3",
-				"d3-quadtree": "3",
-				"d3-random": "3",
-				"d3-scale": "4",
-				"d3-scale-chromatic": "3",
-				"d3-selection": "3",
-				"d3-shape": "3",
-				"d3-time": "3",
-				"d3-time-format": "4",
-				"d3-timer": "3",
-				"d3-transition": "3",
-				"d3-zoom": "3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-array": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-			"license": "ISC",
-			"dependencies": {
-				"internmap": "1 - 2"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-axis": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-			"integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-brush": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-			"integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-dispatch": "1 - 3",
-				"d3-drag": "2 - 3",
-				"d3-interpolate": "1 - 3",
-				"d3-selection": "3",
-				"d3-transition": "3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-chord": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-			"integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-path": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-color": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-contour": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-			"integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "^3.2.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-delaunay": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-			"integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-			"license": "ISC",
-			"dependencies": {
-				"delaunator": "5"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-dispatch": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-			"integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-drag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-			"integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-dispatch": "1 - 3",
-				"d3-selection": "3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-dsv": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-			"integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-			"license": "ISC",
-			"dependencies": {
-				"commander": "7",
-				"iconv-lite": "0.6",
-				"rw": "1"
-			},
-			"bin": {
-				"csv2json": "bin/dsv2json.js",
-				"csv2tsv": "bin/dsv2dsv.js",
-				"dsv2dsv": "bin/dsv2dsv.js",
-				"dsv2json": "bin/dsv2json.js",
-				"json2csv": "bin/json2dsv.js",
-				"json2dsv": "bin/json2dsv.js",
-				"json2tsv": "bin/json2dsv.js",
-				"tsv2csv": "bin/dsv2dsv.js",
-				"tsv2json": "bin/dsv2json.js"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-ease": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-fetch": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-			"integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-dsv": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-force": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-			"integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-dispatch": "1 - 3",
-				"d3-quadtree": "1 - 3",
-				"d3-timer": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-format": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-			"integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-geo": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-			"integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "2.5.0 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-hierarchy": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-			"integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-interpolate": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-color": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-path": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-polygon": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-			"integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-quadtree": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-			"integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-random": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-			"integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-sankey": {
-			"version": "0.12.3",
-			"resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
-			"integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"d3-array": "1 - 2",
-				"d3-shape": "^1.2.0"
-			}
-		},
-		"node_modules/d3-sankey/node_modules/d3-array": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-			"integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"internmap": "^1.0.0"
-			}
-		},
-		"node_modules/d3-sankey/node_modules/d3-path": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/d3-sankey/node_modules/d3-shape": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"d3-path": "1"
-			}
-		},
-		"node_modules/d3-sankey/node_modules/internmap": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-			"integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-			"license": "ISC"
-		},
-		"node_modules/d3-scale": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "2.10.0 - 3",
-				"d3-format": "1 - 3",
-				"d3-interpolate": "1.2.0 - 3",
-				"d3-time": "2.1.1 - 3",
-				"d3-time-format": "2 - 4"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-scale-chromatic": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-			"integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-color": "1 - 3",
-				"d3-interpolate": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-selection": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-			"license": "ISC",
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-shape": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-path": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-time": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "2 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-time-format": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-time": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-timer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-transition": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-			"integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-color": "1 - 3",
-				"d3-dispatch": "1 - 3",
-				"d3-ease": "1 - 3",
-				"d3-interpolate": "1 - 3",
-				"d3-timer": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"d3-selection": "2 - 3"
-			}
-		},
-		"node_modules/d3-zoom": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-			"integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-dispatch": "1 - 3",
-				"d3-drag": "2 - 3",
-				"d3-interpolate": "1 - 3",
-				"d3-selection": "2 - 3",
-				"d3-transition": "2 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/dagre-d3-es": {
-			"version": "7.0.13",
-			"resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz",
-			"integrity": "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==",
-			"license": "MIT",
-			"dependencies": {
-				"d3": "^7.9.0",
-				"lodash-es": "^4.17.21"
-			}
-		},
-		"node_modules/dayjs": {
-			"version": "1.11.19",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-			"integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-			"license": "MIT"
-		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4755,15 +3889,6 @@
 			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
 			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
 			"license": "MIT"
-		},
-		"node_modules/delaunator": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-			"integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
-			"license": "ISC",
-			"dependencies": {
-				"robust-predicates": "^3.0.2"
-			}
 		},
 		"node_modules/dequal": {
 			"version": "2.0.3",
@@ -4853,15 +3978,6 @@
 			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
 			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
 			"license": "MIT"
-		},
-		"node_modules/dompurify": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
-			"integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
-			"license": "(MPL-2.0 OR Apache-2.0)",
-			"optionalDependencies": {
-				"@types/trusted-types": "^2.0.7"
-			}
 		},
 		"node_modules/dset": {
 			"version": "3.1.4",
@@ -5236,12 +4352,6 @@
 				"ufo": "^1.6.1",
 				"uncrypto": "^0.1.3"
 			}
-		},
-		"node_modules/hachure-fill": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
-			"integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
-			"license": "MIT"
 		},
 		"node_modules/hast-util-embedded": {
 			"version": "3.0.0",
@@ -5673,18 +4783,6 @@
 				"@babel/runtime": "^7.23.2"
 			}
 		},
-		"node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"license": "MIT",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/import-meta-resolve": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
@@ -5700,15 +4798,6 @@
 			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.6.tgz",
 			"integrity": "sha512-gtGXVaBdl5mAes3rPcMedEBm12ibjt1kDMFfheul1wUAOVEJW60voNdMVzVkfLN06O7ZaD/rxhfKgtlgtTbMjg==",
 			"license": "MIT"
-		},
-		"node_modules/internmap": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
 		},
 		"node_modules/iron-webcrypto": {
 			"version": "1.2.1",
@@ -5850,36 +4939,6 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/katex": {
-			"version": "0.16.25",
-			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.25.tgz",
-			"integrity": "sha512-woHRUZ/iF23GBP1dkDQMh1QBad9dmr8/PAwNA54VrSOVYgI12MAcE14TqnDdQOdzyEonGzMepYnqBMYdsoAr8Q==",
-			"funding": [
-				"https://opencollective.com/katex",
-				"https://github.com/sponsors/katex"
-			],
-			"license": "MIT",
-			"dependencies": {
-				"commander": "^8.3.0"
-			},
-			"bin": {
-				"katex": "cli.js"
-			}
-		},
-		"node_modules/katex/node_modules/commander": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/khroma": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
-			"integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
-		},
 		"node_modules/kleur": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5898,28 +4957,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/langium": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/langium/-/langium-3.3.1.tgz",
-			"integrity": "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==",
-			"license": "MIT",
-			"dependencies": {
-				"chevrotain": "~11.0.3",
-				"chevrotain-allstar": "~0.3.0",
-				"vscode-languageserver": "~9.0.1",
-				"vscode-languageserver-textdocument": "~1.0.11",
-				"vscode-uri": "~3.0.8"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/layout-base": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
-			"integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
-			"license": "MIT"
-		},
 		"node_modules/local-pkg": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
@@ -5937,12 +4974,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
-		},
-		"node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-			"license": "MIT"
 		},
 		"node_modules/longest-streak": {
 			"version": "3.1.0",
@@ -6000,18 +5031,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/marked": {
-			"version": "16.4.2",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-			"integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
-			"license": "MIT",
-			"bin": {
-				"marked": "bin/marked.js"
-			},
-			"engines": {
-				"node": ">= 20"
 			}
 		},
 		"node_modules/mdast-util-definitions": {
@@ -6342,35 +5361,6 @@
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
 			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
 			"license": "CC0-1.0"
-		},
-		"node_modules/mermaid": {
-			"version": "11.12.1",
-			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.1.tgz",
-			"integrity": "sha512-UlIZrRariB11TY1RtTgUWp65tphtBv4CSq7vyS2ZZ2TgoMjs2nloq+wFqxiwcxlhHUvs7DPGgMjs2aeQxz5h9g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@braintree/sanitize-url": "^7.1.1",
-				"@iconify/utils": "^3.0.1",
-				"@mermaid-js/parser": "^0.6.3",
-				"@types/d3": "^7.4.3",
-				"cytoscape": "^3.29.3",
-				"cytoscape-cose-bilkent": "^4.1.0",
-				"cytoscape-fcose": "^2.2.0",
-				"d3": "^7.9.0",
-				"d3-sankey": "^0.12.3",
-				"dagre-d3-es": "7.0.13",
-				"dayjs": "^1.11.18",
-				"dompurify": "^3.2.5",
-				"katex": "^0.16.22",
-				"khroma": "^2.1.0",
-				"lodash-es": "^4.17.21",
-				"marked": "^16.2.1",
-				"roughjs": "^4.6.6",
-				"stylis": "^4.3.6",
-				"ts-dedent": "^2.2.0",
-				"uuid": "^11.1.0"
-			}
 		},
 		"node_modules/micromark": {
 			"version": "4.0.2",
@@ -7594,6 +6584,7 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
 			"integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.15.0",
@@ -7606,12 +6597,14 @@
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
 			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mlly/node_modules/pkg-types": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
 			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"confbox": "^0.1.8",
@@ -7879,12 +6872,6 @@
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
-		"node_modules/path-data-parser": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
-			"integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
-			"license": "MIT"
-		},
 		"node_modules/path-to-regexp": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -7925,22 +6912,6 @@
 				"confbox": "^0.2.2",
 				"exsolve": "^1.0.7",
 				"pathe": "^2.0.3"
-			}
-		},
-		"node_modules/points-on-curve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
-			"integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
-			"license": "MIT"
-		},
-		"node_modules/points-on-path": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
-			"integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
-			"license": "MIT",
-			"dependencies": {
-				"path-data-parser": "0.1.0",
-				"points-on-curve": "0.2.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -8446,12 +7417,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/robust-predicates": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-			"integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
-			"license": "Unlicense"
-		},
 		"node_modules/rollup": {
 			"version": "4.53.2",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.2.tgz",
@@ -8493,30 +7458,6 @@
 				"@rollup/rollup-win32-x64-msvc": "4.53.2",
 				"fsevents": "~2.3.2"
 			}
-		},
-		"node_modules/roughjs": {
-			"version": "4.6.6",
-			"resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
-			"integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
-			"license": "MIT",
-			"dependencies": {
-				"hachure-fill": "^0.5.2",
-				"path-data-parser": "^0.1.0",
-				"points-on-curve": "^0.2.0",
-				"points-on-path": "^0.2.1"
-			}
-		},
-		"node_modules/rw": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"license": "MIT"
 		},
 		"node_modules/sax": {
 			"version": "1.4.3",
@@ -8756,12 +7697,6 @@
 				"inline-style-parser": "0.2.6"
 			}
 		},
-		"node_modules/stylis": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-			"integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-			"license": "MIT"
-		},
 		"node_modules/supports-color": {
 			"version": "10.2.2",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -8823,15 +7758,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/ts-dedent": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
-			"integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.10"
 			}
 		},
 		"node_modules/tsconfck": {
@@ -9271,19 +8197,6 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"license": "MIT"
 		},
-		"node_modules/uuid": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/esm/bin/uuid"
-			}
-		},
 		"node_modules/vfile": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -9418,55 +8331,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/vscode-jsonrpc": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/vscode-languageserver": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-			"license": "MIT",
-			"dependencies": {
-				"vscode-languageserver-protocol": "3.17.5"
-			},
-			"bin": {
-				"installServerIntoExtension": "bin/installServerIntoExtension"
-			}
-		},
-		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-			"license": "MIT",
-			"dependencies": {
-				"vscode-jsonrpc": "8.2.0",
-				"vscode-languageserver-types": "3.17.5"
-			}
-		},
-		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-			"license": "MIT"
-		},
-		"node_modules/vscode-languageserver-types": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-			"license": "MIT"
-		},
-		"node_modules/vscode-uri": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-			"license": "MIT"
 		},
 		"node_modules/web-namespaces": {
 			"version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"@astrojs/cloudflare": "^12.6.10",
 		"@astrojs/starlight": "^0.36.2",
 		"astro": "^5.6.1",
-		"astro-mermaid": "^1.1.0",
+		"astro-d2": "^0.9.0",
 		"sharp": "^0.34.2"
 	},
 	"devDependencies": {

--- a/src/content/docs/resorts/grandeco.mdx
+++ b/src/content/docs/resorts/grandeco.mdx
@@ -103,24 +103,38 @@ import SeasonTimeline from '../../../components/SeasonTimeline.astro';
 |---|---|---|---|
 | 行き | 3時間30分 | 6:40 | 10:10 |
 
-```mermaid
-flowchart LR
-  classDef station fill:#0f02,stroke:#080;
-  Tokyo:::station@{ shape: rounded, label: "東京駅" }
-  Koriyama:::station@{ shape: rounded, label: "郡山駅" }
-  Inawashiro:::station@{ shape: rounded, label: "猪苗代駅" }
+```d2
+direction: right
 
-  Shinkansen@{ shape: stadium, label: "東北新幹線 約80〜100分" }
-  Bus@{ shape: stadium, label: "[土日・特定日・年末年始] 有料路線バス 約110分" }
-  JR@{ shape: stadium, label: "JR 磐越西線 約40分" }
-  ShuttleBus@{ shape: stadium, label: "無料シャトルバス 約40分" }
+Tokyo: 東京駅
+Koriyama: 郡山駅
+Inawashiro: 猪苗代駅
+Grandeco: グランデコホテル {shape: circle}
 
-  Grandeco@{ shape: circle, label: "グランデコホテル" }
-
-  Tokyo -.- Shinkansen -.-> Koriyama
-  Koriyama -.- JR -.-> Inawashiro
-  Inawashiro -.- ShuttleBus -.-> Grandeco
-  Koriyama -.- Bus -..-> Grandeco
+Tokyo -> Koriyama: "東北新幹線\n約80〜100分" {
+  style: {
+    stroke-dash: 2
+    italic: false
+  }
+}
+Koriyama -> Inawashiro: "JR 磐越西線\n約40分" {
+  style: {
+    stroke-dash: 2
+    italic: false
+  }
+}
+Inawashiro -> Grandeco: "無料シャトルバス\n約40分" {
+  style: {
+    stroke-dash: 2
+    italic: false
+  }
+}
+Koriyama -> Grandeco: "[土日・特定日・年末年始]\n有料路線バス 約110分" {
+  style: {
+    stroke-dash: 2
+    italic: false
+  }
+}
 ```
 
 <details>

--- a/src/content/docs/resorts/nekoma-mountain.mdx
+++ b/src/content/docs/resorts/nekoma-mountain.mdx
@@ -134,19 +134,25 @@ import SeasonTimeline from '../../../components/SeasonTimeline.astro';
 
 東京からは東北新幹線で郡山駅へ。そこから直通バスで約90分。
 
-```mermaid
-flowchart LR
-  classDef station fill:#0f02,stroke:#080;
-  Tokyo:::station@{ shape: rounded, label: "東京駅" }
-  Koriyama:::station@{ shape: rounded, label: "郡山駅" }
+```d2
+direction: right
 
-  Shinkansen@{ shape: stadium, label: "東北新幹線 約80〜100分" }
-  Bus@{ shape: stadium, label: "路線バス 約90分" }
+Tokyo: 東京駅
+Koriyama: 郡山駅
+Bandaisan: 磐梯山温泉ホテル {shape: circle}
 
-  Bandaisan@{ shape: circle, label: "磐梯山温泉ホテル" }
-
-  Tokyo -.- Shinkansen -.-> Koriyama
-  Koriyama -.- Bus -.-> Bandaisan
+Tokyo -> Koriyama: "東北新幹線\n約80〜100分" {
+  style: {
+    stroke-dash: 2
+    italic: false
+  }
+}
+Koriyama -> Bandaisan: "路線バス\n約90分" {
+  style: {
+    stroke-dash: 2
+    italic: false
+  }
+}
 ```
 
 <details>

--- a/src/content/docs/resorts/onikoube.mdx
+++ b/src/content/docs/resorts/onikoube.mdx
@@ -71,24 +71,38 @@ import SeasonTimeline from '../../../components/SeasonTimeline.astro';
 
 東京からは東北新幹線で古川駅へ。そこから送迎シャトルバスまたはJR陸羽東線で移動。
 
-```mermaid
-flowchart LR
-  classDef station fill:#0f02,stroke:#080;
-  Tokyo:::station@{ shape: rounded, label: "東京駅" }
-  Furukawa:::station@{ shape: rounded, label: "古川駅" }
-  Naruko:::station@{ shape: rounded, label: "鳴子温泉駅" }
+```d2
+direction: right
 
-  Shinkansen@{ shape: stadium, label: "東北新幹線 約120分" }
-  Shuttle@{ shape: stadium, label: "送迎シャトルバス 約70分" }
-  JR@{ shape: stadium, label: "JR陸羽東線 約46分" }
-  Bus@{ shape: stadium, label: "大崎市営バス 約45分" }
+Tokyo: 東京駅
+Furukawa: 古川駅
+Naruko: 鳴子温泉駅
+Onikoube: ホテルオニコウベ {shape: circle}
 
-  Onikoube@{ shape: circle, label: "ホテルオニコウベ" }
-
-  Tokyo -.- Shinkansen -.-> Furukawa
-  Furukawa -..- Shuttle -..-> Onikoube
-  Furukawa -.- JR -.-> Naruko
-  Naruko -.- Bus -.-> Onikoube
+Tokyo -> Furukawa: "東北新幹線\n約120分" {
+  style: {
+    stroke-dash: 2
+    italic: false
+  }
+}
+Furukawa -> Onikoube: "送迎シャトルバス\n約70分" {
+  style: {
+    stroke-dash: 2
+    italic: false
+  }
+}
+Furukawa -> Naruko: "JR陸羽東線\n約46分" {
+  style: {
+    stroke-dash: 2
+    italic: false
+  }
+}
+Naruko -> Onikoube: "大崎市営バス\n 約45分" {
+  style: {
+    stroke-dash: 2
+    italic: false
+  }
+}
 ```
 
 <details>


### PR DESCRIPTION
#22

このプルリクエストでは、ドキュメント内の図のレンダリングをMermaidからD2へ移行し、サイトの設定と影響を受けるすべての図を更新します。また、`astro-mermaid`インテグレーションを`astro-d2`に置き換え、関連する依存関係も更新します。

**図のレンダリング移行:**

* リゾートのドキュメントファイル（`grandeco.mdx`、`nekoma-mountain.mdx`、`onikoube.mdx`）内のすべての図は、Mermaid構文からD2構文に書き換えられ、明瞭さと一貫性が向上しました。[[1]](diffhunk://#diff-85a2f9145636567e51c45470d3796a4cd52287a8ec42cde794f0603b07a3d067L106-R137) [[2]](diffhunk://#diff-ea52f645028ac282fe0d7efed6e7b255857c613f3741323462d40a346dbb85adL137-R155) [[3]](diffhunk://#diff-fa2c3b181ccbbe96093d788727bdf54676b70637f7fc02d424248f1c173504e2L74-R105)

**ビルド設定と依存関係:**

* `astro.config.mjs`から`astro-mermaid`インテグレーションが削除され、`astro-d2`に置き換えられました。これにはD2図用のカスタムレイアウトとテーマ設定が含まれます。[[1]](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL4-R4) [[2]](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL19-R23)
* `package.json`の`astro-mermaid`への依存関係が`astro-d2`に置き換えられました。