### PR TITLE
feat: サイドバーのスキー場を県別（北→南）にグループ化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,3 +32,4 @@ Snowcation — スキーリゾート情報サイト。Astro + Starlight で構�
 - コミットメッセージは Conventional Commits 形式 (`feat:`, `fix:`, `docs:`, `chore:` など)
 - 新規作業は新しいブランチを作って行う
 - PR の説明には概要・変更内容・テスト方法・関連 Issue を含める
+- サイドバーの県グループは北→南の順に並べる（青森県 → 秋田県 → 宮城県 → …）

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,10 +25,32 @@ export default defineConfig({
             title: 'Snowcation',
             defaultLocale: 'ja',
             social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/kyosuke/snowcation' }],
+            // 県グループは北→南の順に並べる
             sidebar: [
                 {
-                    label: 'スキー場',
-                    autogenerate: { directory: 'resorts' },
+                    label: '青森県',
+                    items: [
+                        { slug: 'resorts/aomori-spring' },
+                    ],
+                },
+                {
+                    label: '秋田県',
+                    items: [
+                        { slug: 'resorts/tazawako' },
+                    ],
+                },
+                {
+                    label: '宮城県',
+                    items: [
+                        { slug: 'resorts/onikoube' },
+                    ],
+                },
+                {
+                    label: '福島県',
+                    items: [
+                        { slug: 'resorts/grandeco' },
+                        { slug: 'resorts/nekoma-mountain' },
+                    ],
                 },
             ],
         }),


### PR DESCRIPTION
## 概要
サイドバーのナビゲーションを「スキー場」一括表示から県別グループに変更。

## 変更内容
- **astro.config.mjs**: サイドバーを県別（青森県→秋田県→宮城県→福島県）にグループ化。並び順コメント追加
- **CLAUDE.md**: ルールセクションに「県グループは北→南の順に並べる」を追加

## テスト方法
- `npm run build` でビルドが通ることを確認済み
- `npm run dev` でサイドバーが県別に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)