### PR TITLE
chore: Edit/Write 後に oxfmt を自動実行する hooks を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npm run format"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 概要
Claude Code の PostToolUse hooks を設定し、ファイル編集後に自動フォーマットが走るようにする。

## 変更内容
- `.claude/settings.json` を追加
- `Edit` / `Write` ツール実行後に `npm run format`（oxfmt）が自動実行される

## テスト方法
- [ ] Claude Code でファイルを編集し、フォーマットが自動適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)