### PR TITLE
docs: グランデコの今シーズン営業終了情報を追加

### DIFF
--- a/src/components/SeasonTimeline.astro
+++ b/src/components/SeasonTimeline.astro
@@ -121,9 +121,7 @@ const formatDate = (d: Date) => `${d.getMonth() + 1}/${d.getDate()}`;
         <span class="legend-dot closure-dot" />
         <span class="legend-text">
           <strong>クローズ</strong>
-          {closureSegments.map(c => (
-            <span class="legend-dates">{formatDate(c.startDate)} 〜 {formatDate(c.endDate)}</span>
-          ))}
+          <span class="legend-dates">{closureSegments.map(c => `${formatDate(c.startDate)} 〜 ${formatDate(c.endDate)}`).join('、')}</span>
         </span>
       </li>
     )}

--- a/src/content/docs/resorts/grandeco.mdx
+++ b/src/content/docs/resorts/grandeco.mdx
@@ -38,7 +38,10 @@ import GondolaInfo from "../../../components/GondolaInfo.astro";
     { name: "オンシーズン", start: "2025-12-13", end: "2026-03-29", color: "#34A853" },
     { name: "スプリングシーズン", start: "2026-03-30", end: "2026-04-19", color: "#FBBC05" },
   ]}
-  closures={[{ start: "2025-11-22", end: "2025-12-06" }]}
+  closures={[
+    { start: "2025-11-22", end: "2025-12-06" },
+    { start: "2026-04-13", end: "2026-04-19" },
+  ]}
 />
 
 ## リフト・ゴンドラ


### PR DESCRIPTION
## 概要

グランデコ スノーリゾートの 25-26 シーズン営業終了情報を追加。

## 変更内容

- 4/12 が最終営業日のため、スプリングシーズンの 4/13〜4/19 をクローズとして `closures` に追加

## テスト方法

- `npm run build` でビルドが成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)