### PR TITLE
docs: ネコママウンテン北エリアの今シーズン営業終了情報を追加

### DIFF
--- a/src/content/docs/resorts/nekoma-mountain.mdx
+++ b/src/content/docs/resorts/nekoma-mountain.mdx
@@ -38,7 +38,10 @@ import LiftInfo from "../../../components/LiftInfo.astro";
     { name: "営業期間", start: "2025-11-29", end: "2026-03-27", color: "#34A853" },
     { name: "営業期間（春）", start: "2026-03-28", end: "2026-05-06", color: "#FBBC05" },
   ]}
-  closures={[{ start: "2025-11-29", end: "2025-12-06" }]}
+  closures={[
+    { start: "2025-11-29", end: "2025-12-06" },
+    { start: "2026-04-20", end: "2026-05-06" },
+  ]}
 />
 
 ### 南エリア
@@ -74,6 +77,10 @@ import LiftInfo from "../../../components/LiftInfo.astro";
 - 要予約
 
 ※ 12/16〜12/18に利用して確認
+
+### 北エリア営業終了 (4/19)
+
+北エリアは4/19(日)にて今シーズンの営業を終了。
 
 ### 南エリア営業終了 (3/25)
 


### PR DESCRIPTION
## 概要

ネコママウンテン北エリアが 4/19 で今シーズンの営業を終了するため、営業期間の図と詳細情報を更新。

## 変更内容

- SeasonTimeline の closures に 4/20〜5/6 を追加し、クローズ期間を表示
- 詳細セクションに「北エリア営業終了 (4/19)」の記述を追加

## テスト方法

- [ ] `npm run build` が成功すること
- [ ] 北エリアの SeasonTimeline で 4/20 以降がクローズ表示になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)